### PR TITLE
[internals]Remove includes and references to dpcc++ internals

### DIFF
--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -16,7 +16,9 @@
 *  limitations under the License.
 *
 **************************************************************************/
+# ifndef __HIPSYCL__
 #include <CL/sycl/detail/pi.hpp>
+# endif
 #include "cublas_helper.hpp"
 #include "cublas_scope_handle.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/cublas/cublas_extensions.cpp
+++ b/src/blas/backends/cublas/cublas_extensions.cpp
@@ -16,7 +16,9 @@
 *  limitations under the License.
 *
 **************************************************************************/
+#ifndef __HIPSYCL__
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #include "cublas_helper.hpp"
 #include "cublas_scope_handle.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -20,9 +20,9 @@
 #include "cublas_scope_handle.hpp"
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hpp"
-
+#ifndef __HIPSYCL__
 #include <CL/sycl/detail/pi.hpp>
-
+#endif
 namespace oneapi {
 namespace mkl {
 namespace blas {

--- a/src/blas/backends/cublas/cublas_level2.cpp
+++ b/src/blas/backends/cublas/cublas_level2.cpp
@@ -16,7 +16,10 @@
 *  limitations under the License.
 *
 **************************************************************************/
+#ifndef __HIPSYCL__
 #include <CL/sycl/detail/pi.hpp>
+#endif
+
 #include "cublas_helper.hpp"
 #include "cublas_scope_handle.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -16,7 +16,9 @@
 *  limitations under the License.
 *
 **************************************************************************/
+#ifndef __HIPSYCL__
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #include "cublas_helper.hpp"
 #include "cublas_scope_handle.hpp"
 #include "oneapi/mkl/exceptions.hpp"


### PR DESCRIPTION
This PR is meant to eliminate references to dpc++ internals in case hipSYCL is used. This is probably the messiest part of the entire porting process.

TODO: exact description of what happens here