### PR TITLE
[tests][modernize]Make the tests compile with hipSYCL

### DIFF
--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -186,7 +186,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     // Call DPC++ GEMM_BATCH_STRIDE.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     // Call DPC++ GEMM_BATCH_STRIDE.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -136,7 +136,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -181,7 +181,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -208,7 +208,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -263,7 +263,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -46,7 +46,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -121,7 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call DPC++ TRSM_BATCH_STRIDE.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -129,7 +129,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -173,7 +173,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -121,7 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call DPC++ TRSM_BATCH_STRIDE.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -88,7 +88,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMM_BIAS.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -96,7 +96,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BIAS:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -142,7 +142,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -88,7 +88,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMM_BIAS.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -68,7 +68,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ GEMMT.
 
     // Catch asynchronous exceptions
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -76,7 +76,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -68,7 +68,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ GEMMT.
 
     // Catch asynchronous exceptions
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::transpose transb, int n, int k, int lda,
          int ldb, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::transpose transb, int n, int k, int lda,
          int ldb, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -224,7 +224,7 @@ template <typename fp>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fp *alpha, const fp *a, const int *lda,
                  const fp *b, const int *ldb, const fp *beta, fp *c, const int *ldc);
-#ifdef NOT_HIPSYCL
+#ifdef ENABLE_HALF_ROUTINES
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const half *alpha, const half *a, const int *lda,
@@ -291,7 +291,7 @@ template <typename fpa, typename fpc>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fpc *alpha, const fpa *a, const int *lda,
                  const fpa *b, const int *ldb, const fpc *beta, fpc *c, const int *ldc);
-#ifdef NOT_HIPSYCL
+#ifdef ENABLE_HALF_ROUTINES
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const float *alpha, const half *a, const int *lda,

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -224,7 +224,7 @@ template <typename fp>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fp *alpha, const fp *a, const int *lda,
                  const fp *b, const int *ldb, const fp *beta, fp *c, const int *ldc);
-
+#ifdef NOT_HIPSYCL
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const half *alpha, const half *a, const int *lda,
@@ -255,7 +255,7 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(bf);
     oneapi::mkl::aligned_free(cf);
 }
-
+#endif
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const float *alpha, const float *a, const int *lda,
@@ -291,7 +291,7 @@ template <typename fpa, typename fpc>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fpc *alpha, const fpa *a, const int *lda,
                  const fpa *b, const int *ldb, const fpc *beta, fpc *c, const int *ldc);
-
+#ifdef NOT_HIPSYCL
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const float *alpha, const half *a, const int *lda,
@@ -314,7 +314,7 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(af);
     oneapi::mkl::aligned_free(bf);
 }
-
+#endif
 template <typename fp>
 static void symm(CBLAS_LAYOUT layout, CBLAS_SIDE left_right, CBLAS_UPLO uplo, const int *m,
                  const int *n, const fp *alpha, const fp *a, const int *lda, const fp *b,

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -224,11 +224,10 @@ template <typename fp>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fp *alpha, const fp *a, const int *lda,
                  const fp *b, const int *ldb, const fp *beta, fp *c, const int *ldc);
-#ifdef ENABLE_HALF_ROUTINES
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const half *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const half *beta, half *c, const int *ldc) {
+          const int *n, const int *k, const cl::sycl::half *alpha, const cl::sycl::half *a, const int *lda,
+          const cl::sycl::half *b, const int *ldb, const cl::sycl::half *beta, cl::sycl::half *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb, sizec;
     const float alphaf = *alpha;
@@ -255,7 +254,6 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(bf);
     oneapi::mkl::aligned_free(cf);
 }
-#endif
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const float *alpha, const float *a, const int *lda,
@@ -291,11 +289,10 @@ template <typename fpa, typename fpc>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fpc *alpha, const fpa *a, const int *lda,
                  const fpa *b, const int *ldb, const fpc *beta, fpc *c, const int *ldc);
-#ifdef ENABLE_HALF_ROUTINES
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const float *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
+          const int *n, const int *k, const float *alpha, const cl::sycl::half *a, const int *lda,
+          const cl::sycl::half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb;
     if (layout == CblasColMajor) {
@@ -314,7 +311,6 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(af);
     oneapi::mkl::aligned_free(bf);
 }
-#endif
 template <typename fp>
 static void symm(CBLAS_LAYOUT layout, CBLAS_SIDE left_right, CBLAS_UPLO uplo, const int *m,
                  const int *n, const fp *alpha, const fp *a, const int *lda, const fp *b,

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -27,9 +27,10 @@
 #include <type_traits>
 
 #include <CL/sycl.hpp>
+#include "oneapi/mkl/detail/config.hpp"
 
 namespace std {
-#ifdef NOT_HIPSYCL
+#ifdef ENABLE_HALF_ROUTINES
 static cl::sycl::half abs(cl::sycl::half v) {
     if (v < cl::sycl::half(0))
         return -v;
@@ -142,7 +143,7 @@ template <>
 uint8_t rand_scalar() {
     return std::rand() % 128;
 }
-#ifdef NOT_HIPSYCL
+#ifdef ENABLE_HALF_ROUTINES
 template <>
 half rand_scalar() {
     return half(std::rand() % 32000) / half(32000) - half(0.5);

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -30,14 +30,14 @@
 #include "oneapi/mkl/detail/config.hpp"
 
 namespace std {
-#ifdef ENABLE_HALF_ROUTINES
+//#ifdef ENABLE_HALF_ROUTINES
 static cl::sycl::half abs(cl::sycl::half v) {
     if (v < cl::sycl::half(0))
         return -v;
     else
         return v;
 }
-#endif
+//#endif
 } // namespace std
 
 // Complex helpers.
@@ -143,12 +143,12 @@ template <>
 uint8_t rand_scalar() {
     return std::rand() % 128;
 }
-#ifdef ENABLE_HALF_ROUTINES
+//#ifdef ENABLE_HALF_ROUTINES
 template <>
-half rand_scalar() {
-    return half(std::rand() % 32000) / half(32000) - half(0.5);
+cl::sycl::half rand_scalar() {
+    return cl::sycl::half(std::rand() % 32000) / cl::sycl::half(32000) - cl::sycl::half(0.5);
 }
-#endif
+//#endif
 template <typename fp>
 static fp rand_scalar(int mag) {
     fp tmp = fp(mag) + fp(std::rand()) / fp(RAND_MAX) - fp(0.5);

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -29,12 +29,14 @@
 #include <CL/sycl.hpp>
 
 namespace std {
+#ifdef NOT_HIPSYCL
 static cl::sycl::half abs(cl::sycl::half v) {
     if (v < cl::sycl::half(0))
         return -v;
     else
         return v;
 }
+#endif
 } // namespace std
 
 // Complex helpers.
@@ -140,12 +142,12 @@ template <>
 uint8_t rand_scalar() {
     return std::rand() % 128;
 }
-
+#ifdef NOT_HIPSYCL
 template <>
 half rand_scalar() {
     return half(std::rand() % 32000) / half(32000) - half(0.5);
 }
-
+#endif
 template <typename fp>
 static fp rand_scalar(int mag) {
     fp tmp = fp(mag) + fp(std::rand()) / fp(RAND_MAX) - fp(0.5);

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     // Call DPC++ ASUM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     // Call DPC++ ASUM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -103,7 +103,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     // Call DPC++ AXPY.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     // Call DPC++ AXPY.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -108,7 +108,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp alpha) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp alpha) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -59,7 +59,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ COPY.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -59,7 +59,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ COPY.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -58,7 +58,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOT.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -58,7 +58,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOT.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOTC.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOTC.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOTU.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -60,7 +60,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ DOTU.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ IAMAX.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ IAMAX.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ IAMIN.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -57,7 +57,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ IAMIN.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -58,7 +58,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ NRM2.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -58,7 +58,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Call DPC++ NRM2.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_res>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     // Call DPC++ ROT.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     // Call DPC++ ROT.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -45,7 +45,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_scalar c,
          fp_scalar s) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -53,7 +53,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -45,7 +45,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_scalar c,
          fp_scalar s) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -65,7 +65,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call DPC++ ROTG.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -115,7 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -65,7 +65,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call DPC++ ROTG.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     // Call DPC++ ROTM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     // Call DPC++ ROTM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp flag) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp flag) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -63,7 +63,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
     // Call DPC++ ROTMG.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -63,7 +63,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
     // Call DPC++ ROTMG.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -60,7 +60,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     // Call DPC++ SCAL.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -68,7 +68,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -105,7 +105,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -60,7 +60,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     // Call DPC++ SCAL.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_scalar>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alpha) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp, typename fp_scalar>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alpha) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -58,7 +58,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     // Call DPC++ SDSDOT.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -58,7 +58,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     // Call DPC++ SDSDOT.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -66,7 +66,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -43,7 +43,7 @@ namespace {
 
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, float alpha) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -43,7 +43,7 @@ namespace {
 
 int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, float alpha) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -51,7 +51,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -59,7 +59,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ SWAP.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -59,7 +59,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Call DPC++ SWAP.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GBMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GBMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -76,7 +76,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa, int m, int n,
          int kl, int ku, fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa, int m, int n,
          int kl, int ku, fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -67,7 +67,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -75,7 +75,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -67,7 +67,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa, int m, int n,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -122,7 +122,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa, int m, int n,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GER.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GER.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GERC.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GERC.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GERU.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     // Call DPC++ GERU.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int incx, int incy,
          int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -65,7 +65,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HBMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -65,7 +65,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HBMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, int k,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, int k,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HEMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HEMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -62,7 +62,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -62,7 +62,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER2.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER2.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n,
          fp_scalar alpha, int incx, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n,
          fp_scalar alpha, int incx, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -62,7 +62,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPR.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -62,7 +62,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPR.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPR2.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HPR2.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n,
          fp_scalar alpha, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp, typename fp_scalar>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n,
          fp_scalar alpha, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SBMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -64,7 +64,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SBMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, int k,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, int k,
          fp alpha, fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPR.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPR.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPR2.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SPR2.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          fp beta, int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -61,7 +61,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR2.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -63,7 +63,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR2.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int incy, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower, int n, fp alpha,
          int incx, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const &e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -64,7 +64,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TBMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -64,7 +64,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TBMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int k, int incx,
          int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int k, int incx,
          int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -64,7 +64,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TBSV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -64,7 +64,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TBSV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int k, int incx,
          int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int k, int incx,
          int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TPMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TPMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TPSV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TPSV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TRMV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TRMV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TRSV.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -62,7 +62,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ TRSV.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx, int lda) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose transa, oneapi::mkl::diag unit_nonunit, int n, int incx, int lda) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -144,7 +144,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 
 class GemmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device*, oneapi::mkl::layout>> {};
-#ifdef NOT_HIPSYCL
+#ifdef ENABLE_HALF_ROUTINES
 TEST_P(GemmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -144,41 +144,39 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 
 class GemmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device*, oneapi::mkl::layout>> {};
-#ifdef ENABLE_HALF_ROUTINES
 TEST_P(GemmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
 
 TEST_P(GemmTests, RealHalfPrecision) {
-    half alpha(2.0);
-    half beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, half>(
+    cl::sycl::half alpha(2.0);
+    cl::sycl::half beta(3.0);
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
-#endif
 TEST_P(GemmTests, RealSinglePrecision) {
     float alpha(2.0);
     float beta(3.0);

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     // Call DPC++ GEMM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {
@@ -144,7 +144,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 
 class GemmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device*, oneapi::mkl::layout>> {};
-
+#ifdef NOT_HIPSYCL
 TEST_P(GemmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);
@@ -178,7 +178,7 @@ TEST_P(GemmTests, RealHalfPrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
-
+#endif
 TEST_P(GemmTests, RealSinglePrecision) {
     float alpha(2.0);
     float beta(3.0);

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
          oneapi::mkl::transpose transb, int m, int n, int k, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
          oneapi::mkl::transpose transb, int m, int n, int k, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ HEMM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ HEMM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, int m, int n, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, int m, int n, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER2K.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HER2K.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldb, int ldc, fp alpha,
          fp_scalar beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldb, int ldc, fp alpha,
          fp_scalar beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HERK.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ HERK.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldc, fp_scalar alpha,
          fp_scalar beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldc, fp_scalar alpha,
          fp_scalar beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ SYMM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ SYMM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, int m, int n, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, int m, int n, int lda, int ldb, int ldc, fp alpha,
          fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR2K.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYR2K.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldb, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldb, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYRK.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     // Call DPC++ SYRK.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -73,7 +73,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -46,7 +46,7 @@ template <typename fp>
 int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
          oneapi::mkl::transpose trans, int n, int k, int lda, int ldc, fp alpha, fp beta) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ TRMM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ TRMM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
          oneapi::mkl::diag unit_nonunit, int m, int n, int lda, int ldb, fp alpha) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
          oneapi::mkl::diag unit_nonunit, int m, int n, int lda, int ldb, fp alpha) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ TRSM.
 
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     // Call DPC++ TRSM.
 
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
          oneapi::mkl::diag unit_nonunit, int m, int n, int lda, int ldb, fp alpha) {
     // Catch asynchronous exceptions.
-    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
+    auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -47,7 +47,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
          oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
          oneapi::mkl::diag unit_nonunit, int m, int n, int lda, int ldb, fp alpha) {
     // Catch asynchronous exceptions.
-    auto exception_handler = [](exception_list exceptions) {
+    cl::sycl::async_handler exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -107,7 +107,11 @@ int main(int argc, char** argv) {
                         if (dev.is_gpu() && vendor_id == NVIDIA_ID)
                             continue;
 #endif
+#ifdef __HIPSYCL__
+                        if (dev.is_accelerator())
+#else
                         if (!dev.is_accelerator())
+#endif
                             local_devices.push_back(dev);
                     }
                 }

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -67,7 +67,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -79,15 +79,15 @@ public:
     // method to call any tests, switch between rt and ct
     template <typename... Args>
     int operator()(cl::sycl::device* dev, Args... args) {
-        auto exception_handler = [](sycl::exception_list exceptions) {
+        cl::sycl::async_handler exception_handler = [](cl::sycl::exception_list exceptions) {
             for (std::exception_ptr const& e : exceptions) {
                 try {
                     std::rethrow_exception(e);
                 }
-                catch (sycl::exception const& e) {
+                catch (cl::sycl::exception const& e) {
                     std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                               << e.what() << std::endl
-                              << "OpenCL status: " << e.get_cl_code() << std::endl;
+                              << "OpenCL status: " << e.what() << std::endl;
                 }
             }
         };

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -79,7 +79,7 @@ public:
     // method to call any tests, switch between rt and ct
     template <typename... Args>
     int operator()(cl::sycl::device* dev, Args... args) {
-        cl::sycl::async_handler exception_handler = [](cl::sycl::exception_list exceptions) {
+        auto exception_handler = [](cl::sycl::exception_list exceptions) {
             for (std::exception_ptr const& e : exceptions) {
                 try {
                     std::rethrow_exception(e);

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -76,7 +76,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -55,13 +55,13 @@ public:
         std::vector<Type> r(n_gen);
 
         try {
-            cl::sycl::buffer<Type, 1> r_buffer(r.data(), r.size());
+            sycl::buffer<Type, 1> r_buffer(r.data(), r.size());
 
             Engine engine(queue, SEED);
             Distr distr(args...);
             oneapi::mkl::rng::generate(distr, engine, n_gen, r_buffer);
         }
-        catch (cl::sycl::exception const& e) {
+        catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
                       << "OpenCL status: " << e.what() << std::endl;
@@ -88,9 +88,9 @@ public:
         using Type = typename Distr::result_type;
 
 #ifdef CALL_RT_API
-        auto ua = cl::sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue);
+        auto ua = sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue);
 #else
-        auto ua = cl::sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue.get_queue());
+        auto ua = sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue.get_queue());
 #endif
         std::vector<Type, decltype(ua)> r(n_gen, ua);
 

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -44,6 +44,7 @@
 
 #define POISSON_ARGS 0.5
 
+using namespace cl;
 template <typename Distr, typename Engine>
 class statistics_test {
 public:
@@ -54,16 +55,16 @@ public:
         std::vector<Type> r(n_gen);
 
         try {
-            sycl::buffer<Type, 1> r_buffer(r.data(), r.size());
+            cl::sycl::buffer<Type, 1> r_buffer(r.data(), r.size());
 
             Engine engine(queue, SEED);
             Distr distr(args...);
             oneapi::mkl::rng::generate(distr, engine, n_gen, r_buffer);
         }
-        catch (sycl::exception const& e) {
+        catch (cl::sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;
@@ -87,9 +88,9 @@ public:
         using Type = typename Distr::result_type;
 
 #ifdef CALL_RT_API
-        auto ua = sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue);
+        auto ua = cl::sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue);
 #else
-        auto ua = sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue.get_queue());
+        auto ua = cl::sycl::usm_allocator<Type, sycl::usm::alloc::shared, 64>(queue.get_queue());
 #endif
         std::vector<Type, decltype(ua)> r(n_gen, ua);
 
@@ -102,7 +103,7 @@ public:
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;


### PR DESCRIPTION
This PR concenrs the tests. The following two changes were made:
* use `cl::sycl::async_handler` instead of `auto` type 
* use `.what()` instead of using `get_cl_code()`